### PR TITLE
chore(deps): bump Django from 2.2.8 to 2.2.9 in /app

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,6 +1,6 @@
 astroid==2.2.5
 colorama==0.4.1
-Django==2.2.8
+Django==2.2.9
 django-environ==0.4.5
 GDAL==2.3.3
 isort==4.3.21


### PR DESCRIPTION
Fix CVE-2019-19844