### PR TITLE
renovate.json: Omit explicit additionalReviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,9 +6,6 @@
   "addLabels": [
     "dependencies"
   ],
-  "additionalReviewers": [
-    "stephengtuggy"
-  ],
   "assigneesFromCodeOwners": true,
   "reviewersFromCodeOwners": true,
   "minimumReleaseAge": "1d",


### PR DESCRIPTION
**What does your Pull Request seek to accomplish?**
Omit explicit additionalReviewers from renovate.json, now that Code Owners have been assigned for every file in the repository.

**Please list any related issues, using [closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) if appropriate**
N/A